### PR TITLE
Use django_guid to fetch and apply an Azure correlationId

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -21,7 +21,6 @@ from storages.utils import safe_join
 from storages.utils import setting
 from storages.utils import to_bytes
 
-
 try:
     from django_guid import get_guid
 except ImportError:

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -291,8 +291,8 @@ class AzureStorageTest(TestCase):
 
     # From boto3
 
-    @mock.patch('django_guid.get_guid', return_value=None)
-    def test_storage_save(self):
+    @mock.patch('storages.backends.azure_storage.get_guid', return_value=None)
+    def test_storage_save(self, mocked_get_guid):
         """
         Test saving a file
         """
@@ -307,7 +307,8 @@ class AzureStorageTest(TestCase):
                 content_settings='content_settings_foo',
                 max_concurrency=2,
                 timeout=20,
-                overwrite=True)
+                overwrite=True,
+                headers={})
             c_mocked.assert_called_once_with(
                 content_type='text/plain',
                 content_encoding=None,
@@ -336,8 +337,8 @@ class AzureStorageTest(TestCase):
                 content_encoding=None,
                 cache_control=None)
 
-    @mock.patch('django_guid.get_guid', return_value=None)
-    def test_storage_open_write(self):
+    @mock.patch('storages.backends.azure_storage.get_guid', return_value=None)
+    def test_storage_open_write(self, mocked_get_guid):
         """
         Test opening a file in write mode
         """
@@ -354,7 +355,8 @@ class AzureStorageTest(TestCase):
             content_settings=mock.ANY,
             max_concurrency=2,
             timeout=20,
-            overwrite=True)
+            overwrite=True,
+            headers={})
 
     def test_storage_open_write_with_guid(self):
         """
@@ -376,16 +378,15 @@ class AzureStorageTest(TestCase):
             max_concurrency=2,
             timeout=20,
             overwrite=True,
-            hedaers=headers)
+            headers=headers)
 
-    @mock.patch('django_guid.get_guid', return_value=None)
-    def test_storage_exists(self):
+    @mock.patch('storages.backends.azure_storage.get_guid', return_value=None)
+    def test_storage_exists(self, mocked_get_guid):
         blob_name = "blob"
         client_mock = mock.MagicMock()
         self.storage._client.get_blob_client.return_value = client_mock
         self.assertTrue(self.storage.exists(blob_name))
-        # self.assertEqual(client_mock.get_blob_properties.call_count, 1)
-        client_mock.get_blob_properties.assert_called_once_with()
+        client_mock.get_blob_properties.assert_called_once_with(headers={})
 
     def test_storage_exists_with_guid(self):
         blob_name = "blob"
@@ -395,11 +396,11 @@ class AzureStorageTest(TestCase):
         self.assertTrue(self.storage.exists(blob_name))
         client_mock.get_blob_properties.assert_called_once_with(headers=headers)
 
-    @mock.patch('django_guid.get_guid', return_value=None)
-    def test_delete_blob(self):
+    @mock.patch('storages.backends.azure_storage.get_guid', return_value=None)
+    def test_delete_blob(self, mocked_get_guid):
         self.storage.delete("name")
         self.storage._client.delete_blob.assert_called_once_with(
-            "name", timeout=20)
+            "name", timeout=20, headers={})
 
     def test_delete_blob_with_guid(self):
         headers = set_and_expect_guid()
@@ -407,8 +408,8 @@ class AzureStorageTest(TestCase):
         self.storage._client.delete_blob.assert_called_once_with(
             "name", timeout=20, headers=headers)
 
-    @mock.patch('django_guid.get_guid', return_value=None)
-    def test_storage_listdir_base(self):
+    @mock.patch('storages.backends.azure_storage.get_guid', return_value=None)
+    def test_storage_listdir_base(self, mocked_get_guid):
         file_names = ["some/path/1.txt", "2.txt", "other/path/3.txt", "4.txt"]
 
         result = []
@@ -420,7 +421,7 @@ class AzureStorageTest(TestCase):
 
         dirs, files = self.storage.listdir("")
         self.storage._client.list_blobs.assert_called_with(
-            name_starts_with="", timeout=20)
+            name_starts_with="", timeout=20, headers={})
 
         self.assertEqual(len(dirs), 2)
         for directory in ["some", "other"]:
@@ -449,8 +450,8 @@ class AzureStorageTest(TestCase):
         self.storage._client.list_blobs.assert_called_with(
             name_starts_with="", timeout=20, headers=headers)
 
-    @mock.patch('django_guid.get_guid', return_value=None)
-    def test_storage_listdir_subdir(self):
+    @mock.patch('storages.backends.azure_storage.get_guid', return_value=None)
+    def test_storage_listdir_subdir(self, mocked_get_guid):
         file_names = ["some/path/1.txt", "some/2.txt"]
 
         result = []
@@ -462,7 +463,7 @@ class AzureStorageTest(TestCase):
 
         dirs, files = self.storage.listdir("some/")
         self.storage._client.list_blobs.assert_called_with(
-            name_starts_with="some/", timeout=20)
+            name_starts_with="some/", timeout=20, headers={})
 
         self.assertEqual(len(dirs), 1)
         self.assertTrue(

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -366,7 +366,6 @@ class AzureStorageTest(TestCase):
         content = 'new content'
         headers = set_and_expect_guid()
 
-
         file = self.storage.open(name, 'w')
         file.write(content)
         written_file = file.file

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from datetime import timedelta
 from unittest import mock
 
@@ -11,11 +12,9 @@ from django.test import TestCase
 from django.test import override_settings
 from django.utils import timezone
 from django.utils.timezone import make_aware
+from django_guid import set_guid
 
 from storages.backends import azure_storage
-
-from django_guid import set_guid
-import uuid
 
 
 def set_and_expect_guid():

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 	DJANGO_SETTINGS_MODULE = tests.settings
 	PYTHONWARNINGS = always
 	PYTHONDONTWRITEBYTECODE = 1
-commands = pytest tests/test_azure.py {posargs} -v
+commands = pytest --cov=storages tests/ {posargs}
 deps =
 	django3.2: django~=3.2.9
 	django4.0: django~=4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,14 @@ setenv =
 	DJANGO_SETTINGS_MODULE = tests.settings
 	PYTHONWARNINGS = always
 	PYTHONDONTWRITEBYTECODE = 1
-commands = pytest --cov=storages tests/ {posargs}
+commands = pytest tests/test_azure.py {posargs} -v
 deps =
 	django3.2: django~=3.2.9
 	django4.0: django~=4.0.0
 	django4.1: django~=4.1.0
 	djangomain: https://github.com/django/django/archive/main.tar.gz
 	cryptography
+	django-guid
 	pytest
 	pytest-cov
 	rsa


### PR DESCRIPTION
Set Azure's correlation-id header from the guid kept by django_guid. That module is optional, so I can't depend on it being available at runtime. If it is available, the app might not have called set_guid in the current context.

- Try to import django_guid
- If the import succeeds, call get_guid from that module
- If a non-empty result comes back, apply the value as the correlation_id when talking to storage
